### PR TITLE
Descriptor rewrite

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,6 @@ use silt::model::MVP;
 use silt::prelude::*;
 use silt::properties::{DeviceFeaturesRequest, DeviceFeatures};
 use silt::storage::buffer::{get_bound_buffer};
-use silt::storage::descriptors::UniformWrite;
 use silt::sync::{QueueRequest, QueueType};
 
 fn main() {

--- a/src/model.rs
+++ b/src/model.rs
@@ -4,7 +4,7 @@ use memoffset::offset_of;
 use crate::pipeline::BindableVertex;
 use crate::prelude::*;
 use crate::storage::buffer::{self, Buffer};
-use crate::storage::descriptors::{Bindable, BindingDescription, DescriptorFrequency, UniformWrite};
+use crate::storage::descriptors::{Bindable, BindingDescription, DescriptorFrequency};
 use crate::sync::CommandPool;
 
 #[derive(Clone, Copy, Debug)]
@@ -91,8 +91,6 @@ pub struct MVP {
 }
 
 impl Bindable for MVP {
-    type Write = UniformWrite;
-
     fn binding(&self) -> BindingDescription {
         BindingDescription {
             descriptor_type: vk::DescriptorType::UNIFORM_BUFFER,
@@ -101,13 +99,6 @@ impl Bindable for MVP {
             descriptor_count: 1,
             stage_flags: vk::ShaderStageFlags::empty(),
         }
-    }
-
-    fn pool_size(&self) -> vk::DescriptorPoolSize {
-        vk::DescriptorPoolSize::builder()
-            .ty(vk::DescriptorType::UNIFORM_BUFFER)
-            .descriptor_count(1)
-            .build()
     }
 }
 

--- a/src/storage/buffer.rs
+++ b/src/storage/buffer.rs
@@ -1,8 +1,14 @@
-use super::{image::Image, descriptors::{Bindable, DescriptorWrite}};
+use super::{
+    descriptors::{Bindable, DescriptorWrite, DescriptorWriter, ResourceType},
+    image::Image,
+};
 use crate::prelude::*;
 use crate::sync::CommandPool;
 use anyhow::{anyhow, Result};
-use std::{cell::{RefCell, Cell}, marker::PhantomData};
+use std::{
+    cell::{Cell, RefCell},
+    marker::PhantomData,
+};
 
 #[derive(Clone, Debug)]
 pub struct Buffer {
@@ -43,9 +49,14 @@ impl<T: Bindable> Destructible for BoundBuffer<T> {
 impl<T: Bindable> BoundBuffer<T> {
     fn copy(&self, loader: &Loader, parity: Parity, value: &T) {
         if let Some(ref mapping) = self.mappings {
-            mapping.get(parity).copy_from_slice(std::slice::from_ref(value));
+            mapping
+                .get(parity)
+                .copy_from_slice(std::slice::from_ref(value));
         } else {
-            unsafe { map_buffer(loader, &self.buffers.get(parity)).copy_from_slice(std::slice::from_ref(value)) };
+            unsafe {
+                map_buffer(loader, &self.buffers.get(parity))
+                    .copy_from_slice(std::slice::from_ref(value))
+            };
         }
     }
 
@@ -54,6 +65,20 @@ impl<T: Bindable> BoundBuffer<T> {
         f(&mut value);
         self.copy(loader, parity, &value);
         self.inner.set(value);
+    }
+}
+
+impl<T: Bindable + Default> DescriptorWriter for BoundBuffer<T> {
+    fn get_write<'a>(&'a self) -> DescriptorWrite<'a> {
+        DescriptorWrite::from_buffer(
+            self.buffers.map(|buffer| {
+                vk::DescriptorBufferInfo::builder()
+                    .buffer(buffer.buffer)
+                    .offset(0)
+                    .range(buffer.size)
+            }),
+            T::default().binding()
+        )
     }
 }
 
@@ -194,7 +219,9 @@ impl<'a, T: Copy> Drop for MemoryMapping<'a, T> {
         unsafe {
             self.loader.map(|loader| {
                 if loader.allocator.get_mapped_ptr(self.allocation).is_err() {
-                    loader.device.unmap_memory(loader.allocator.get_memory(self.allocation).unwrap());
+                    loader
+                        .device
+                        .unmap_memory(loader.allocator.get_memory(self.allocation).unwrap());
                 }
             });
         }
@@ -218,7 +245,7 @@ impl<'a, T: Copy> MemoryMapping<'a, T> {
         MemoryMapping {
             loader: None,
             allocation,
-            align: RefCell::new(align)
+            align: RefCell::new(align),
         }
     }
 }
@@ -244,7 +271,10 @@ pub unsafe fn map_buffer<'a, T: Copy>(loader: &'a Loader, buffer: &Buffer) -> Me
     MemoryMapping::new(loader, buffer.allocation, get_align(loader, buffer))
 }
 
-pub unsafe fn map_buffer_persistent<T: Copy>(loader: &Loader, buffer: &Buffer) -> MemoryMapping<'static, T> {
+pub unsafe fn map_buffer_persistent<T: Copy>(
+    loader: &Loader,
+    buffer: &Buffer,
+) -> MemoryMapping<'static, T> {
     MemoryMapping::new_persistent(buffer.allocation, get_align(loader, buffer))
 }
 
@@ -280,7 +310,10 @@ pub fn upload_to_gpu<T: Copy>(
     Ok(buffer)
 }
 
-pub fn get_bound_buffer<T: Bindable + Copy>(loader: &Loader, usage: vk::BufferUsageFlags) -> Result<BoundBuffer<T>> {
+pub fn get_bound_buffer<T: Bindable + Copy>(
+    loader: &Loader,
+    usage: vk::BufferUsageFlags,
+) -> Result<BoundBuffer<T>> {
     let buffer_ci = BufferCreateInfo {
         size: std::mem::size_of::<T>() as u64,
         name: None,
@@ -294,6 +327,6 @@ pub fn get_bound_buffer<T: Bindable + Copy>(loader: &Loader, usage: vk::BufferUs
     Ok(BoundBuffer {
         buffers,
         mappings: Some(mappings),
-        inner: Cell::default()
+        inner: Cell::default(),
     })
 }

--- a/src/storage/descriptors.rs
+++ b/src/storage/descriptors.rs
@@ -24,6 +24,10 @@ pub enum ResourceType {
     Image, Buffer
 }
 
+pub trait DescriptorWriter {
+    fn get_write<'a>(&'a self) -> DescriptorWrite<'a>;
+}
+
 pub struct DescriptorWrite<'a> {
     pub resource_ty: ResourceType,
     pub buffer_info: ParitySet<vk::DescriptorBufferInfoBuilder<'a>>,
@@ -32,6 +36,24 @@ pub struct DescriptorWrite<'a> {
 }
 
 impl<'a> DescriptorWrite<'a> {
+    pub fn from_buffer(buffer_info: ParitySet<vk::DescriptorBufferInfoBuilder<'a>>, binding: BindingDescription) -> Self {
+        Self {
+            resource_ty: ResourceType::Buffer,
+            buffer_info,
+            image_info: ParitySet::from_fn(|| vk::DescriptorImageInfo::builder()),
+            binding
+        }
+    }
+
+    pub fn from_image(image_info: ParitySet<vk::DescriptorImageInfoBuilder<'a>>, binding: BindingDescription) -> Self {
+        Self {
+            resource_ty: ResourceType::Buffer,
+            buffer_info: ParitySet::from_fn(|| vk::DescriptorBufferInfo::builder()),
+            image_info,
+            binding
+        }
+    }
+
     fn write(&self, loader: &Loader, sets: &ParitySet<vk::DescriptorSet>) {
         unsafe {
             loader.device.update_descriptor_sets(

--- a/src/storage/descriptors.rs
+++ b/src/storage/descriptors.rs
@@ -1,5 +1,4 @@
 use crate::{pipeline::Shader, prelude::*};
-use super::buffer::{Buffer, FromTypedBufferParity};
 
 use std::collections::HashMap;
 use anyhow::Result;
@@ -11,78 +10,49 @@ pub trait BindableVec {
 }
 
 pub trait Bindable: Copy + Default {
-    type Write: DescriptorWrite;
-
     fn binding(&self) -> BindingDescription;
-    fn pool_size(&self) -> vk::DescriptorPoolSize;
-}
-
-pub trait DescriptorWrite {
-    fn write(&mut self, loader: &Loader, sets: &ParitySet<vk::DescriptorSet>);
-    fn binding(&self) -> BindingDescription;
-    fn is_constant(&self) -> bool {
-        false
+    fn pool_size(&self) -> vk::DescriptorPoolSize {
+        vk::DescriptorPoolSize::builder()
+            .descriptor_count(self.binding().descriptor_count)
+            .ty(self.binding().descriptor_type)
+            .build()
     }
 }
 
-pub trait DescriptorWriter {
-    fn writer(&self) -> Box<dyn DescriptorWrite>;
+#[derive(Clone, Copy, Debug)]
+pub enum ResourceType {
+    Image, Buffer
 }
 
-pub struct UniformWrite {
-    binding: BindingDescription,
-    info: ParitySet<vk::DescriptorBufferInfo>,
+pub struct DescriptorWrite<'a> {
+    pub resource_ty: ResourceType,
+    pub buffer_info: ParitySet<vk::DescriptorBufferInfoBuilder<'a>>,
+    pub image_info: ParitySet<vk::DescriptorImageInfoBuilder<'a>>,
+    pub binding: BindingDescription,
 }
 
-impl UniformWrite {
-    pub fn new<T: Bindable + Default>(info: ParitySet<vk::DescriptorBufferInfo>) -> UniformWrite {
-        UniformWrite {
-            binding: T::default().binding(),
-            info,
-        }
-    }
-}
-
-impl<T: Bindable + Copy> FromTypedBufferParity<T> for UniformWrite {
-    fn from(value: &ParitySet<Buffer>) -> Self {
-        Self::new::<T>(
-            value
-                .iter()
-                .map(|buffer| {
-                    vk::DescriptorBufferInfo::builder()
-                        .buffer(buffer.buffer)
-                        .offset(0)
-                        .range(buffer.size)
-                        .build()
-                })
-                .collect(),
-        )
-    }
-}
-
-impl DescriptorWrite for UniformWrite {
-    fn write(&mut self, loader: &Loader, sets: &ParitySet<vk::DescriptorSet>) {
-        let writes = izip!(self.info.iter(), sets.iter())
-            .map(|(info, set)| {
-                vk::WriteDescriptorSet::builder()
-                .buffer_info(std::slice::from_ref(info))
-                .descriptor_type(self.binding.descriptor_type)
-                .dst_binding(self.binding.binding)
-                .dst_set(*set)
-                .build()
-            })
-            .collect_vec();
-
+impl<'a> DescriptorWrite<'a> {
+    fn write(&self, loader: &Loader, sets: &ParitySet<vk::DescriptorSet>) {
         unsafe {
             loader.device.update_descriptor_sets(
-                &writes,
-                &[],
-            )
-        }
-    }
+                &izip!(self.buffer_info.iter(), self.image_info.iter(), sets.iter())
+                    .map(|(buffer_info, image_info, set)| {
+                        let mut write = vk::WriteDescriptorSet::builder()
+                            .descriptor_type(self.binding.descriptor_type)
+                            .dst_binding(self.binding.binding)
+                            .dst_set(*set);
 
-    fn binding(&self) -> BindingDescription {
-        self.binding
+                        match self.resource_ty {
+                            ResourceType::Image => write = write.image_info(std::slice::from_ref(image_info)),
+                            ResourceType::Buffer => write = write.buffer_info(std::slice::from_ref(buffer_info)),
+                        }
+
+                        write.build()
+                    })
+                    .collect_vec(), 
+                &[]
+            );
+        }
     }
 }
 
@@ -196,18 +166,19 @@ pub fn get_layouts(loader: &Loader, shaders: &[&dyn Shader]) -> Result<Layouts> 
     })
 }
 
-pub unsafe fn get_descriptors(
+pub unsafe fn get_descriptors<'a>(
     loader: &Loader,
     layouts: &Layouts,
-    writes: Vec<Box<dyn DescriptorWrite>>,
+    writes: impl IntoIterator<Item = &'a DescriptorWrite<'a>> + Clone,
 ) -> Result<(
     vk::DescriptorPool,
     HashMap<DescriptorFrequency, ParitySet<vk::DescriptorSet>>,
 )> {
     let pool_sizes = writes
-        .iter()
+        .clone()
+        .into_iter()
         .map(|write| {
-            let binding = write.binding();
+            let binding = write.binding;
             vk::DescriptorPoolSize {
                 ty: binding.descriptor_type,
                 descriptor_count: binding.descriptor_count,
@@ -236,9 +207,9 @@ pub unsafe fn get_descriptors(
         })
         .collect::<Result<HashMap<_, _>>>()?;
 
-    for mut write in writes {
-        let set = sets.get(&write.binding().frequency).unwrap();
-        write.as_mut().write(loader, &set);
+    for write in writes {
+        let set = sets.get(&write.binding.frequency).unwrap();
+        write.write(loader, &set);
     }
 
     Ok((pool, sets))


### PR DESCRIPTION
Reworked descriptor system to utilize unified `DescriptorWrite` struct instead of OOP
Improved memory safety by deferring `.build()` calls
Integrated constant images and per-frame buffers with new system